### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    labels:
+      - dependencies
+      - rust
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Enable Dependabot for the `cargo` and `github-actions` ecosystems
- Weekly schedule (Mondays 09:00 America/Los_Angeles)
- Group minor + patch updates to reduce PR churn; majors get their own PRs
- Conventional-commit prefixes: `chore(deps)` for cargo, `chore(ci)` for actions
- Labels: `dependencies` + `rust` / `github-actions`

## Test plan
- [ ] Config validates (Dependabot parses the file on first run; surfaces errors in Insights → Dependency graph → Dependabot)
- [ ] All required status checks pass (`test (ubuntu-24.04)`, `test (macOS-latest)`, `lint`, `format`, `readme`)
- [ ] No unexpected changes to Cargo/Actions dependencies in this PR itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management for Cargo packages and GitHub Actions. Updates are scheduled weekly with automatic commit message prefixes and PR labeling. Dependencies are grouped to batch minor and patch updates for streamlined review and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->