### PR TITLE
chore(ci): include major updates in dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,9 @@ updates:
       - dependencies
       - rust
     groups:
-      cargo-minor-and-patch:
+      cargo-all:
         update-types:
+          - major
           - minor
           - patch
 
@@ -37,5 +38,6 @@ updates:
     groups:
       github-actions:
         update-types:
+          - major
           - minor
           - patch


### PR DESCRIPTION
## Summary

- Include `major` update type in both cargo and github-actions dependabot groups
- Previously only minor/patch were grouped, so major bumps (e.g. `toml` 0.8→0.9, `reqwest` 0.12→0.13) each created individual PRs (#5-#8) instead of being batched into the group PR (#4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to include major version checks for Cargo and GitHub Actions alongside minor and patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->