### PR TITLE
feat(cli): print help on no args, drop unimplemented --recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ redskull: grayskull for rust.
 
 Specify the crates.io packages name. Redskull can also accept a github url.
 
-Usage: redskull [OPTIONS] [ARGS]...
+Usage: redskull [OPTIONS] <ARGS>...
 
 Arguments:
-  [ARGS]...
+  <ARGS>...
           Crates.io package names or GitHub URLs
 
 Options:
@@ -56,9 +56,6 @@ Options:
 
       --output <OUTPUT>
           Path to where the recipe will be created
-
-  -r, --recursive
-          Recursively run grayskull on missing dependencies
 
       --tag <GITHUB_RELEASE_TAG>
           If tag is specified, Redskull will build from release tag

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,7 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use anyhow::{Result, ensure};
+use anyhow::Result;
 use clap::builder::styling;
 use clap::{ColorChoice, Parser as ClapParser, ValueEnum};
 use crates_io_api::SyncClient;
@@ -65,6 +65,7 @@ const STYLES: styling::Styles = styling::Styles::styled()
     name = "redskull",
     color = ColorChoice::Auto,
     styles = STYLES,
+    arg_required_else_help = true,
     version = built_info::VERSION.as_str())
  ]
 #[allow(clippy::struct_excessive_bools)]
@@ -76,10 +77,6 @@ struct Opts {
     /// Path to where the recipe will be created.
     #[clap(long)]
     output: Option<PathBuf>,
-
-    /// Recursively run grayskull on missing dependencies.
-    #[clap(long, short = 'r', default_value = "false")]
-    recursive: bool,
 
     /// If tag is specified, Redskull will build from release tag
     #[clap(long = "tag")]
@@ -159,6 +156,7 @@ struct Opts {
     workspace_path: Option<String>,
 
     /// Crates.io package names or GitHub URLs.
+    #[clap(required = true)]
     args: Vec<String>,
 }
 
@@ -347,9 +345,6 @@ fn set_crates_io_source(
 
 #[allow(clippy::too_many_lines)]
 fn redskull_from_opts(opts: &Opts) -> Result<()> {
-    ensure!(!opts.args.is_empty(), "No packages given. Please specify at least one crate.");
-    ensure!(!opts.recursive, "Recursive dependency resolution is not yet implemented.");
-
     let user_agent =
         format!("redskull/{} (https://github.com/fg-labs/redskull)", built_info::VERSION.as_str());
     let timeout = std::time::Duration::from_secs(30);
@@ -1029,4 +1024,30 @@ fn setup() -> Opts {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     Opts::parse()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Opts;
+    use clap::Parser;
+
+    #[test]
+    fn parse_fails_when_no_args_at_all() {
+        // arg_required_else_help triggers: no arguments -> help printed, parse errors.
+        assert!(Opts::try_parse_from(["redskull"]).is_err());
+    }
+
+    #[test]
+    fn parse_fails_when_only_flags_given_without_positional() {
+        // Regression: previously arg_required_else_help alone allowed clap to parse
+        // successfully with an empty `args` vec when only flags were passed, causing
+        // a silent no-op exit. The positional must be `required` to catch this.
+        assert!(Opts::try_parse_from(["redskull", "--bioconda"]).is_err());
+    }
+
+    #[test]
+    fn parse_succeeds_with_positional_crate_name() {
+        let opts = Opts::try_parse_from(["redskull", "serde"]).expect("should parse");
+        assert_eq!(opts.args, vec!["serde".to_string()]);
+    }
 }


### PR DESCRIPTION
## Summary

Two small CLI hygiene fixes from user feedback on the `holodeck` recipe generation:

- **No-args prints help.** Previously running `redskull` with no arguments errored with `No packages given. Please specify at least one crate.`. Now clap's `arg_required_else_help` prints `--help` instead.
- **Drop `-r/--recursive`.** The flag was a non-functional leftover from `grayskull` — the help text even said "Recursively run grayskull on missing dependencies" and the code just bailed with "not yet implemented". Cargo deps are compiled from source at package build time rather than packaged separately in conda, so recursive recipe generation doesn't map onto Rust. Transitive `-sys` crate detection already happens via `Cargo.lock` inspection.

README usage block is regenerated by `.github/scripts/update-docs.sh`.

## Test plan

- [x] `cargo ci-test` / `cargo ci-lint` / `cargo ci-fmt` pass
- [x] `./target/debug/redskull` (no args) prints the help block
- [x] `./target/debug/redskull --help` shows no `-r/--recursive` entry
- [x] `./target/debug/redskull holodeck --bioconda -o /tmp/...` still generates the recipe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line help text and usage documentation

* **Refactor**
  * Removed the `--recursive` (`-r`) command-line option
  * Streamlined argument validation using built-in CLI framework handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->