### PR TITLE
fix(recipe): emit stdlib('c') unconditionally and template crates.io URL

### DIFF
--- a/src/lib/recipe.rs
+++ b/src/lib/recipe.rs
@@ -114,10 +114,10 @@ impl Requirements {
         if has_cxx_deps {
             build.push(Requirement::simple("{{ compiler('cxx') }}"));
         }
-        // Bioconda lints require stdlib('c') whenever a C/C++ compiler is present.
-        if has_c_deps || has_cxx_deps {
-            build.push(Requirement::simple("{{ stdlib('c') }}"));
-        }
+        // Bioconda's compiler_needs_stdlib_c lint requires stdlib('c') whenever any
+        // {{ compiler(...) }} appears — including compiler('rust') — so emit it
+        // unconditionally alongside the Rust compiler below.
+        build.push(Requirement::simple("{{ stdlib('c') }}"));
         build.push(Requirement::simple("{{ compiler('rust') }}"));
 
         if cargo_bundle_licenses {

--- a/src/lib/recipe_builder.rs
+++ b/src/lib/recipe_builder.rs
@@ -103,7 +103,21 @@ impl RecipeBuilder {
     }
 
     pub fn crates_io_source(&mut self, dl_path: &str, sha256: &str) -> &mut Self {
-        self.source_url = format!("https://crates.io{dl_path}");
+        // Replace the resolved version segment with the `{{ version }}` jinja
+        // placeholder so the URL auto-updates across version bumps — bioconda
+        // lints reject URLs that hardcode the version. The crate-name segment
+        // stays literal since the recipe `name` may differ (via --recipe-name).
+        let needle = format!("/{}/", self.version);
+        // Guard against drift in the crates.io `dl_path` format: `replacen` returns
+        // the input unchanged if the needle isn't present, which would silently ship
+        // a URL that hardcodes the version and fails bioconda lint.
+        debug_assert!(
+            dl_path.contains(&needle),
+            "crates_io_source: dl_path {dl_path:?} does not contain version segment {needle:?}; \
+             templated URL would hardcode the version and fail bioconda lint"
+        );
+        let templated = dl_path.replacen(&needle, "/{{ version }}/", 1);
+        self.source_url = format!("https://crates.io{templated}");
         self.source_filename = format!("{}.{{{{ version }}}}.tar.gz", self.name);
         self.source_sha256 = sha256.to_string();
         self

--- a/tests/tier1.rs
+++ b/tests/tier1.rs
@@ -277,7 +277,9 @@ fn test_pure_rust_requirements() {
     assert!(names.contains(&"{{ compiler('rust') }}"));
     assert!(!names.contains(&"{{ compiler('c') }}"), "pure Rust should not include compiler('c')");
     assert!(!names.contains(&"{{ compiler('cxx') }}"));
-    assert!(!names.contains(&"{{ stdlib('c') }}"), "pure Rust should not include stdlib('c')");
+    // bioconda's compiler_needs_stdlib_c lint requires stdlib('c') alongside any
+    // compiler(...), including compiler('rust').
+    assert!(names.contains(&"{{ stdlib('c') }}"), "compiler('rust') requires stdlib('c')");
     assert!(!names.contains(&"cargo-bundle-licenses"));
     assert!(!names.contains(&"clangdev"));
     assert!(!names.contains(&"pkg-config"));
@@ -410,6 +412,26 @@ fn test_builder_crates_io_source() {
     assert!(output.contains("abc123sha"), "should use provided SHA");
     assert!(!output.contains("github.com"), "should not reference GitHub");
     assert!(output.contains("fqtk --help"), "binary test command");
+    // URL must use {{ version }} jinja placeholder so it auto-updates on version bumps
+    // (bioconda rejects URLs that hardcode the version).
+    assert!(
+        output.contains("https://crates.io/api/v1/crates/fqtk/{{ version }}/download"),
+        "crates.io URL should template the version segment"
+    );
+    assert!(
+        !output.contains("/api/v1/crates/fqtk/0.3.1/download"),
+        "crates.io URL should not hardcode the version"
+    );
+}
+
+// If the crates.io dl_path format ever drifts and the version segment can't be found,
+// silently hardcoding the version would ship a recipe that fails bioconda lint.
+// The `debug_assert!` in `crates_io_source` catches this in debug builds / tests.
+#[test]
+#[should_panic(expected = "does not contain version segment")]
+fn test_builder_crates_io_source_panics_when_version_segment_missing() {
+    let mut builder = RecipeBuilder::new("fqtk", "0.3.1");
+    builder.crates_io_source("/api/v1/crates/fqtk/download", "abc123sha");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two bioconda-lint fixes surfaced while using redskull against the `holodeck` recipe.

- **Always emit `{{ stdlib('c') }}`.** Bioconda's `compiler_needs_stdlib_c` lint fires on any `{{ compiler(...) }}` in the build section — including `{{ compiler('rust') }}`. Since `compiler('rust')` is always emitted, `stdlib('c')` is now also emitted unconditionally. Previously it was gated on C/C++ deps, so pure-Rust crates (e.g. `hexyl`) slipped through. For `holodeck` the stdlib line was already present by luck because its `libdeflate`/`libgit2`/`zlib` deps set `has_c_deps=true`.
- **Template `{{ version }}` in crates.io URLs.** The crates.io URL was baked in with the resolved version (e.g. `.../holodeck/0.2.0/download`), which bioconda rejects because the URL can't auto-update on version bumps. The version segment is now replaced with `{{ version }}`. The crate-name segment stays literal since the recipe name may differ from the crate name via `--recipe-name`.

Before (holodeck via `--source crates-io`):
```yaml
url: https://crates.io/api/v1/crates/holodeck/0.2.0/download
```
After:
```yaml
url: https://crates.io/api/v1/crates/holodeck/{{ version }}/download
```

## Test plan

- [x] `cargo ci-test` / `cargo ci-lint` / `cargo ci-fmt` pass
- [x] `test_pure_rust_requirements` flipped: pure Rust now requires `stdlib('c')`
- [x] `test_builder_crates_io_source` asserts the URL templates `{{ version }}` and does not hardcode `0.3.1`
- [x] End-to-end: `redskull --bioconda --source crates-io holodeck` emits templated URL
- [x] End-to-end: `redskull --bioconda hexyl` (pure Rust) now emits `{{ stdlib('c') }}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rust build requirements now always include the C standard library, ensuring consistent build behavior for pure Rust projects.

* **Refactor**
  * Crates.io download URLs are now templated to reference versions dynamically, preventing hardcoded version paths and improving reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->