### PR TITLE
fix(recipe): emit compiler('c') with clangdev for bindgen recipes

### DIFF
--- a/src/lib/recipe.rs
+++ b/src/lib/recipe.rs
@@ -97,7 +97,7 @@ impl Requirements {
     /// * `cargo_bundle_licenses` - include CBL in build deps
     /// * `has_c_deps` - crate links C code (adds compiler('c'))
     /// * `has_cxx_deps` - crate links C++ code (adds compiler('cxx'))
-    /// * `has_bindgen` - crate uses bindgen (adds clangdev)
+    /// * `has_bindgen` - crate uses bindgen (adds clangdev and compiler('c'))
     /// * `build_tools` - which build tools to include (pkg-config, make, cmake)
     pub fn for_rust_crate(
         cargo_bundle_licenses: bool,
@@ -108,7 +108,11 @@ impl Requirements {
     ) -> Self {
         let mut build = vec![];
 
-        if has_c_deps {
+        // bindgen invokes a C compiler on wrapper headers at build time, so
+        // any recipe that pulls in clangdev must also expose `compiler('c')`.
+        // Bioconda recipes that emit `clangdev` without `compiler('c')` fail
+        // the `should_use_compilers` lint.
+        if has_c_deps || has_bindgen {
             build.push(Requirement::simple("{{ compiler('c') }}"));
         }
         if has_cxx_deps {

--- a/tests/tier1.rs
+++ b/tests/tier1.rs
@@ -330,6 +330,40 @@ fn test_requirements_with_bindgen_adds_clangdev() {
     let reqs = Requirements::for_rust_crate(false, false, false, true, &no_tools);
     let names: Vec<&str> = reqs.build.iter().map(|r| r.name.as_str()).collect();
     assert!(names.contains(&"clangdev"));
+    // bindgen invokes a C compiler on wrapper headers, so compiler('c') must
+    // accompany clangdev; bioconda's `should_use_compilers` lint rejects
+    // recipes that ship clangdev without it.
+    assert!(
+        names.contains(&"{{ compiler('c') }}"),
+        "bindgen requires compiler('c'); got: {names:?}"
+    );
+}
+
+/// Regression for issue #17: a `--bioconda` recipe with bindgen-pulling
+/// dependencies must emit `compiler('c')` alongside `clangdev`, not silently
+/// drop it.
+#[test]
+fn test_bioconda_recipe_with_bindgen_emits_compiler_c() {
+    let mut builder = RecipeBuilder::new("tricord", "0.1.0");
+    builder
+        .github_source("fg-labs", "tricord", "deadbeef")
+        .license("MIT")
+        .add_binary("tricorder")
+        .bioconda(true)
+        .cargo_bundle_licenses(true)
+        .needs_bindgen(true);
+
+    let (recipe, _script) = builder.build();
+    let output = MetaYamlRenderer.render(&recipe);
+
+    assert_contains(&output, "{{ compiler('c') }}", "bindgen recipe must emit compiler('c')");
+    assert_contains(&output, "{{ stdlib('c') }}", "bindgen recipe must emit stdlib('c')");
+    assert_contains(&output, "clangdev", "bindgen recipe must emit clangdev");
+
+    // compiler('c') must appear before stdlib('c') to match bioconda convention.
+    let cc_pos = output.find("{{ compiler('c') }}").expect("compiler('c') present");
+    let stdlib_pos = output.find("{{ stdlib('c') }}").expect("stdlib('c') present");
+    assert!(cc_pos < stdlib_pos, "compiler('c') must appear before stdlib('c')");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Emit `{{ compiler('c') }}` in `requirements/build` whenever bindgen is detected (i.e. whenever `clangdev` is being emitted), so generated bioconda recipes pass the `should_use_compilers` lint.
- Add a regression test mirroring the bioconda flow from the issue: bioconda + bindgen → both `compiler('c')` and `stdlib('c')`, with `compiler('c')` ordered first.

Bindgen invokes a C compiler on wrapper headers at build time, so a recipe that ships `clangdev` without `compiler('c')` is wrong regardless of bioconda — the change is gated on `has_bindgen`, not on the `--bioconda` flag.

Repro from the issue (`fg-labs/tricord` v0.1.0 transitively depends on `libproc` → `bindgen`):

before:
```yaml
requirements:
  build:
    - {{ stdlib('c') }}
    - {{ compiler('rust') }}
    - cargo-bundle-licenses
    - clangdev
```

after:
```yaml
requirements:
  build:
    - {{ compiler('c') }}
    - {{ stdlib('c') }}
    - {{ compiler('rust') }}
    - cargo-bundle-licenses
    - clangdev
```

Closes #17

## Test plan

- [x] `cargo ci-test` — new unit test (`test_bioconda_recipe_with_bindgen_emits_compiler_c`) and updated assertions in `test_requirements_with_bindgen_adds_clangdev`
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] End-to-end: `redskull https://github.com/fg-labs/tricord --tag v0.1.0 --bioconda --output /tmp/out` now emits `compiler('c')` ahead of `stdlib('c')`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rust crates using bindgen now properly expose C compiler requirements in Bioconda recipes.

* **Tests**
  * Added regression test for bindgen recipe generation.
  * Updated test assertions for compiler component validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->