### PR TITLE
fix(recipe): use {{ name }} in source.url template

### DIFF
--- a/src/lib/recipe_builder.rs
+++ b/src/lib/recipe_builder.rs
@@ -86,8 +86,8 @@ impl RecipeBuilder {
     }
 
     pub fn github_source(&mut self, owner: &str, repo: &str, sha256: &str) -> &mut Self {
-        self.source_url =
-            format!("https://github.com/{owner}/{repo}/archive/v{{{{ version }}}}.tar.gz");
+        let url = format!("https://github.com/{owner}/{repo}/archive/v{{{{ version }}}}.tar.gz");
+        self.source_url = templatize_recipe_name_segment(&url, &self.name);
         self.source_filename = format!("{}-{{{{ version }}}}.tar.gz", self.name);
         self.source_sha256 = sha256.to_string();
         self
@@ -96,7 +96,7 @@ impl RecipeBuilder {
     /// Set source from a pre-resolved GitHub URL template and SHA256.
     /// Use this when the URL template and SHA256 have been computed from the actual archive.
     pub fn github_source_resolved(&mut self, url_template: &str, sha256: &str) -> &mut Self {
-        self.source_url = url_template.to_string();
+        self.source_url = templatize_recipe_name_segment(url_template, &self.name);
         self.source_filename = format!("{}-{{{{ version }}}}.tar.gz", self.name);
         self.source_sha256 = sha256.to_string();
         self
@@ -106,18 +106,21 @@ impl RecipeBuilder {
         // Replace the resolved version segment with the `{{ version }}` jinja
         // placeholder so the URL auto-updates across version bumps — bioconda
         // lints reject URLs that hardcode the version. The crate-name segment
-        // stays literal since the recipe `name` may differ (via --recipe-name).
+        // is replaced with `{{ name }}` only when it matches the recipe name;
+        // when `--recipe-name` is set and the two differ, the literal crate
+        // name must stay so the URL still resolves on crates.io.
         let needle = format!("/{}/", self.version);
         // Guard against drift in the crates.io `dl_path` format: `replacen` returns
         // the input unchanged if the needle isn't present, which would silently ship
         // a URL that hardcodes the version and fails bioconda lint.
-        debug_assert!(
+        assert!(
             dl_path.contains(&needle),
             "crates_io_source: dl_path {dl_path:?} does not contain version segment {needle:?}; \
              templated URL would hardcode the version and fail bioconda lint"
         );
         let templated = dl_path.replacen(&needle, "/{{ version }}/", 1);
-        self.source_url = format!("https://crates.io{templated}");
+        let url = format!("https://crates.io{templated}");
+        self.source_url = templatize_recipe_name_segment(&url, &self.name);
         self.source_filename = format!("{}.{{{{ version }}}}.tar.gz", self.name);
         self.source_sha256 = sha256.to_string();
         self
@@ -393,5 +396,73 @@ impl RecipeBuilder {
         };
 
         (recipe, script)
+    }
+}
+
+/// Replace any path segment `/{name}/` in `url` with `/{{ name }}/` so the
+/// generated recipe reuses the `{% set name %}` Jinja variable instead of
+/// repeating the literal crate/recipe name. Only exact path-segment matches
+/// are substituted (the surrounding slashes are required), so domains and
+/// unrelated path components are never touched.
+///
+/// When the recipe name differs from the upstream crate/repo path segment
+/// (e.g. via `--recipe-name`), the URL is returned unchanged.
+fn templatize_recipe_name_segment(url: &str, recipe_name: &str) -> String {
+    if recipe_name.is_empty() {
+        return url.to_string();
+    }
+    let needle = format!("/{recipe_name}/");
+    url.replace(&needle, "/{{ name }}/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::templatize_recipe_name_segment;
+
+    #[test]
+    fn templatize_substitutes_github_repo_segment() {
+        let url = "https://github.com/fg-labs/tricord/archive/v{{ version }}.tar.gz";
+        assert_eq!(
+            templatize_recipe_name_segment(url, "tricord"),
+            "https://github.com/fg-labs/{{ name }}/archive/v{{ version }}.tar.gz",
+        );
+    }
+
+    #[test]
+    fn templatize_substitutes_refs_tags_url() {
+        let url = "https://github.com/foo/bar/archive/refs/tags/v{{ version }}.tar.gz";
+        assert_eq!(
+            templatize_recipe_name_segment(url, "bar"),
+            "https://github.com/foo/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz",
+        );
+    }
+
+    #[test]
+    fn templatize_substitutes_crates_io_segment() {
+        let url = "https://crates.io/api/v1/crates/serde/{{ version }}/download";
+        assert_eq!(
+            templatize_recipe_name_segment(url, "serde"),
+            "https://crates.io/api/v1/crates/{{ name }}/{{ version }}/download",
+        );
+    }
+
+    #[test]
+    fn templatize_leaves_url_unchanged_when_segment_missing() {
+        // Recipe name doesn't appear as a full path segment.
+        let url = "https://github.com/fg-labs/tricord/archive/v{{ version }}.tar.gz";
+        assert_eq!(templatize_recipe_name_segment(url, "different-name"), url);
+    }
+
+    #[test]
+    fn templatize_does_not_match_partial_segment() {
+        // `tri` is a substring of `tricord` but not a full segment.
+        let url = "https://github.com/fg-labs/tricord/archive/v{{ version }}.tar.gz";
+        assert_eq!(templatize_recipe_name_segment(url, "tri"), url);
+    }
+
+    #[test]
+    fn templatize_skips_empty_recipe_name() {
+        let url = "https://github.com/foo/bar/archive/v{{ version }}.tar.gz";
+        assert_eq!(templatize_recipe_name_segment(url, ""), url);
     }
 }

--- a/tests/tier1.rs
+++ b/tests/tier1.rs
@@ -412,26 +412,97 @@ fn test_builder_crates_io_source() {
     assert!(output.contains("abc123sha"), "should use provided SHA");
     assert!(!output.contains("github.com"), "should not reference GitHub");
     assert!(output.contains("fqtk --help"), "binary test command");
-    // URL must use {{ version }} jinja placeholder so it auto-updates on version bumps
-    // (bioconda rejects URLs that hardcode the version).
+    // URL must use both `{{ name }}` and `{{ version }}` jinja placeholders so the
+    // recipe template stays DRY and auto-updates on version bumps (bioconda rejects
+    // URLs that hardcode the version).
     assert!(
-        output.contains("https://crates.io/api/v1/crates/fqtk/{{ version }}/download"),
-        "crates.io URL should template the version segment"
+        output.contains("https://crates.io/api/v1/crates/{{ name }}/{{ version }}/download"),
+        "crates.io URL should template the crate-name and version segments"
     );
     assert!(
         !output.contains("/api/v1/crates/fqtk/0.3.1/download"),
         "crates.io URL should not hardcode the version"
     );
+    assert!(
+        !output.contains("/api/v1/crates/fqtk/{{ version }}/download"),
+        "crates.io URL should not hardcode the crate name when it matches the recipe name"
+    );
 }
 
 // If the crates.io dl_path format ever drifts and the version segment can't be found,
 // silently hardcoding the version would ship a recipe that fails bioconda lint.
-// The `debug_assert!` in `crates_io_source` catches this in debug builds / tests.
+// The `assert!` in `crates_io_source` catches this in all builds.
 #[test]
 #[should_panic(expected = "does not contain version segment")]
 fn test_builder_crates_io_source_panics_when_version_segment_missing() {
     let mut builder = RecipeBuilder::new("fqtk", "0.3.1");
     builder.crates_io_source("/api/v1/crates/fqtk/download", "abc123sha");
+}
+
+/// Regression for issue #19: the GitHub `source.url` should reuse `{{ name }}`
+/// when the recipe name matches the repo path segment. Bioconda recipes
+/// hardcoding the crate name in the URL fail the DRY-template convention.
+#[test]
+fn test_builder_github_url_templates_name_when_matching() {
+    let mut builder = RecipeBuilder::new("tricord", "0.1.0");
+    builder.github_source("fg-labs", "tricord", "deadbeef").license("MIT").add_binary("tricorder");
+
+    let (recipe, _script) = builder.build();
+    let output = MetaYamlRenderer.render(&recipe);
+
+    assert_contains(
+        &output,
+        "https://github.com/fg-labs/{{ name }}/archive/v{{ version }}.tar.gz",
+        "GitHub URL should template the recipe-name segment",
+    );
+    assert!(
+        !output.contains("github.com/fg-labs/tricord/"),
+        "GitHub URL should not hardcode the recipe name as a path segment"
+    );
+}
+
+/// Regression for issue #19 (negative case): when the recipe name and the
+/// upstream repo name differ — typically because `--recipe-name` was used —
+/// the URL must keep the literal repo name so it still resolves on GitHub.
+#[test]
+fn test_builder_github_url_keeps_repo_name_when_recipe_name_differs() {
+    let mut builder = RecipeBuilder::new("ska2", "0.3.12");
+    builder.github_source("bacpop", "ska.rust", "deadbeef").license("MIT").add_binary("ska");
+
+    let (recipe, _script) = builder.build();
+    let output = MetaYamlRenderer.render(&recipe);
+
+    assert_contains(
+        &output,
+        "https://github.com/bacpop/ska.rust/archive/v{{ version }}.tar.gz",
+        "differing repo name must stay literal",
+    );
+    assert!(
+        !output.contains("{{ name }}/archive"),
+        "should not template the URL when the recipe name doesn't match the repo path"
+    );
+}
+
+/// Regression for issue #19: pre-resolved GitHub URL templates (the path
+/// `process_github_only` and `resolve_github_source` use) should be
+/// templatized too, including the `archive/refs/tags/...` form.
+#[test]
+fn test_builder_github_source_resolved_templates_name() {
+    let mut builder = RecipeBuilder::new("tricord", "0.1.0");
+    builder.github_source_resolved(
+        "https://github.com/fg-labs/tricord/archive/refs/tags/v{{ version }}.tar.gz",
+        "deadbeef",
+    );
+    builder.license("MIT").add_binary("tricorder");
+
+    let (recipe, _script) = builder.build();
+    let output = MetaYamlRenderer.render(&recipe);
+
+    assert_contains(
+        &output,
+        "https://github.com/fg-labs/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz",
+        "refs/tags URL template should also be templated",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Substitute `{{ name }}` for the recipe-name path segment in `source.url`, so the generated recipe reuses the `{% set name %}` Jinja variable instead of repeating the literal crate / repo name.
- Applies in three places:
  - `github_source` (legacy direct-construction path)
  - `github_source_resolved` (the path used by `process_github_only` and `resolve_github_source`, including the `archive/refs/tags/...` form)
  - `crates_io_source` (the `/api/v1/crates/{name}/{{ version }}/download` segment, on top of the existing version templating)
- The substitution is gated on a full path-segment match. When `--recipe-name` makes the recipe name differ from the upstream repo / crate name, the URL keeps the literal segment so it still resolves upstream.

Repro from the issue (`fg-labs/tricord` v0.1.0):

before:
```yaml
source:
  url: https://github.com/fg-labs/tricord/archive/v{{ version }}.tar.gz
```

after:
```yaml
source:
  url: https://github.com/fg-labs/{{ name }}/archive/v{{ version }}.tar.gz
```

Crates.io output also picks this up:
```yaml
source:
  url: https://crates.io/api/v1/crates/{{ name }}/{{ version }}/download
```

Closes #19

## Test plan

- [x] `cargo ci-test` — new module-level unit tests in `recipe_builder` for the helper, and three new end-to-end tests in `tier1.rs` covering the matching, non-matching, and `archive/refs/tags/` cases
- [x] `cargo ci-fmt`
- [x] `cargo ci-lint`
- [x] End-to-end: `redskull https://github.com/fg-labs/tricord --tag v0.1.0 --bioconda --output /tmp/out` now emits `{{ name }}` in `source.url`
- [x] End-to-end: `redskull fqtk --bioconda --source crates-io --output /tmp/out` emits `{{ name }}/{{ version }}` in the crates.io URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source URLs for GitHub and crates.io dependencies now properly use templating with `{{ name }}` and `{{ version }}` placeholders instead of hardcoding values, improving recipe flexibility and reusability.

* **Tests**
  * Enhanced test coverage for source URL templating behavior, including GitHub and crates.io segment substitution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->