### PR TITLE
fix(renderer): emit fn: directive so conda-build can extract source tarballs

### DIFF
--- a/src/lib/recipe_builder.rs
+++ b/src/lib/recipe_builder.rs
@@ -121,7 +121,9 @@ impl RecipeBuilder {
         let templated = dl_path.replacen(&needle, "/{{ version }}/", 1);
         let url = format!("https://crates.io{templated}");
         self.source_url = templatize_recipe_name_segment(&url, &self.name);
-        self.source_filename = format!("{}.{{{{ version }}}}.tar.gz", self.name);
+        // Use `-` (not `.`) to match the github_source pattern and the actual
+        // top-level directory name inside the crate tarball (`<name>-<version>/`).
+        self.source_filename = format!("{}-{{{{ version }}}}.tar.gz", self.name);
         self.source_sha256 = sha256.to_string();
         self
     }

--- a/src/lib/renderer.rs
+++ b/src/lib/renderer.rs
@@ -45,6 +45,13 @@ impl MetaYamlRenderer {
     fn render_source(&self, out: &mut String, source: &Source) {
         writeln!(out, "source:").unwrap();
         writeln!(out, "  url: {}", source.url).unwrap();
+        // Emit `fn:` so conda-build can recognize the format and auto-strip
+        // the single top-level directory inside the tarball. Without it,
+        // crates.io URLs (which end in `/download`, no extension) produce a
+        // build where `cargo` can't find Cargo.toml in the work dir.
+        if !source.filename.is_empty() {
+            writeln!(out, "  fn: {}", source.filename).unwrap();
+        }
         writeln!(out, "  sha256: {}", source.sha256).unwrap();
         writeln!(out).unwrap();
     }

--- a/tests/tier1.rs
+++ b/tests/tier1.rs
@@ -520,6 +520,35 @@ fn test_builder_crates_io_source() {
         !output.contains("/api/v1/crates/fqtk/{{ version }}/download"),
         "crates.io URL should not hardcode the crate name when it matches the recipe name"
     );
+    // The `fn:` directive is required because the crates.io download URL ends in
+    // `/download` (no extension), so conda-build can't infer the archive format.
+    // Without `fn:`, the tarball isn't auto-extracted/auto-stripped and `cargo` can't
+    // find Cargo.toml in the work dir at build time. The filename uses `-` between
+    // name and version to match the actual top-level directory inside the tarball.
+    assert!(
+        output.contains("fn: fqtk-{{ version }}.tar.gz"),
+        "crates.io recipe must declare fn: <name>-{{{{ version }}}}.tar.gz so conda-build extracts and strips the tarball"
+    );
+}
+
+#[test]
+fn test_renderer_emits_fn_directive_when_filename_set() {
+    // The `fn:` directive tells conda-build the archive's filename so it can
+    // recognize the format (tar.gz) and auto-strip the single top-level directory.
+    // This matters most for crates.io URLs that end in `/download` (no extension),
+    // but is also useful for any source where the URL doesn't reveal the format.
+    let recipe = minimal_recipe("test", "1.0.0");
+    let output = render(&recipe);
+    assert_contains(&output, "fn: test-1.0.0.tar.gz", "render_source should emit fn: line");
+}
+
+#[test]
+fn test_renderer_skips_fn_directive_when_filename_empty() {
+    // Belt-and-suspenders: an empty filename should not emit a stray `fn:` line.
+    let mut recipe = minimal_recipe("test", "1.0.0");
+    recipe.source.filename = String::new();
+    let output = render(&recipe);
+    assert!(!output.contains("\n  fn:"), "render_source should omit fn: when filename is empty");
 }
 
 // If the crates.io dl_path format ever drifts and the version segment can't be found,


### PR DESCRIPTION
## Summary

The `Source` struct has a `filename` field that's populated by both `github_source` and `crates_io_source`, but `MetaYamlRenderer::render_source` never wrote it to the output. As a result the rendered `meta.yaml` had no `fn:` line, and conda-build couldn't determine the archive format from crates.io URLs (which end in `/download` and have no extension).

Without extension-driven format detection, conda-build doesn't auto-strip the single top-level directory inside the tarball, so `cargo install --path .` in the generated `build.sh` fails with `could not find Cargo.toml in .../work or any parent directory`.

## Repro (before this PR)

```sh
redskull --bioconda --source crates-io --recipe-name mako fg-mako
# stage in a bioconda-recipes-like layout, run conda-build → fails inside cargo metadata
```

The generated `meta.yaml` source section looked like:

```yaml
source:
  url: https://crates.io/api/v1/crates/fg-mako/{{ version }}/download
  sha256: e3d81fa75b6283bdd1895fdedf55743403e24db09a3a59ab357d4558c6942fc6
```

— no `fn:`, so conda-build treats `download` as an unknown blob, drops it in `work/` as-is, and `cargo install --path .` fails because Cargo.toml is at `work/fg-mako-0.1.0/Cargo.toml`.

## Fix

Two small changes:

1. **`renderer.rs:45-50`** — `render_source` now emits `  fn: <filename>` between `url:` and `sha256:` whenever `source.filename` is non-empty. With `fn:` set, conda-build sees the `.tar.gz` extension and applies its standard archive handling (extract + strip the single top-level directory).

2. **`recipe_builder.rs:124`** — `crates_io_source` previously built `source_filename` with `{name}.{{ version }}.tar.gz` (a `.` separator). The `github_source` path uses `{name}-{{ version }}.tar.gz` (a `-` separator), and the actual top-level directory inside both archive types is named `<name>-<version>/`. Aligning the crates.io filename to use `-` matches both the github_source pattern and the on-disk directory name. Until this PR the typo was invisible because `filename` was never rendered, but as soon as `render_source` starts using it, the `-` separator is what conda-build needs to find the work tree.

## Tests

Three additions:

- `test_renderer_emits_fn_directive_when_filename_set` — verifies the new `fn:` line appears in rendered output.
- `test_renderer_skips_fn_directive_when_filename_empty` — belt-and-suspenders edge case (no stray `fn:` line if `filename` is empty).
- Updated `test_builder_crates_io_source` to assert the rendered recipe declares `fn: fqtk-{{ version }}.tar.gz`.

## Discovered

While generating a Bioconda recipe for `fg-mako` (mako on bioconda) via `redskull --bioconda --source crates-io`. After regenerating with `--source github` (the default) the recipe built end-to-end on osx-arm64. With this PR, the `--source crates-io` path also produces a working recipe.

## Test plan

- [x] `cargo test --tests` — all 18 + 103 + 9 + 2 + 3 tests pass locally.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated crates.io source filename format to use dash-separated naming convention
  * Added `fn:` field support in generated conda-build recipes when source filename is specified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->