### PR TITLE
fix(sys-deps): treat vendored compression -sys crates as C-compiler-only

### DIFF
--- a/src/lib/sys_deps.rs
+++ b/src/lib/sys_deps.rs
@@ -8,16 +8,14 @@
 
 /// Returns (conda_package_name, optional_platform_selector) pairs
 /// for a given Rust crate name. Returns empty vec for unknown crates.
+///
+/// Only crates that dynamically link a system shared library belong here. The
+/// compression `-sys` crates (libdeflate-sys, zstd-sys, ...) deliberately do
+/// *not* appear: they vendor their C sources and statically link by default,
+/// so they need a C compiler but no conda host/run dependency. See
+/// [`is_vendored_static_sys_crate`].
 pub fn map_sys_crate(crate_name: &str) -> Vec<(&'static str, Option<&'static str>)> {
     match crate_name {
-        // Compression
-        "libz-sys" | "libz-ng-sys" => vec![("zlib", None)],
-        "bzip2-sys" => vec![("bzip2", None)],
-        "lzma-sys" => vec![("xz", None)],
-        "libdeflate-sys" => vec![("libdeflate", None)],
-        "lz4-sys" => vec![("lz4", None)],
-        "zstd-sys" => vec![("zstd", None)],
-
         // TLS/crypto — openssl excluded on macOS (uses system SSL)
         "openssl-sys" => vec![("openssl", Some("not osx"))],
 
@@ -68,11 +66,31 @@ pub fn detect_host_deps(dependency_names: &[&str]) -> Vec<(&'static str, Option<
 /// (they bundle and statically link their own C sources).
 const C_ONLY_CRATES: &[&str] = &["mimalloc", "libmimalloc-sys"];
 
+/// `-sys` crates that vendor their C sources and statically link them by
+/// default. They need a C compiler at build time but *not* a conda host/run
+/// dependency, `pkg-config`, or `make`/`cmake` — the bundled sources are
+/// compiled directly via the `cc` crate.
+///
+/// These are kept separate from [`map_sys_crate`] because emitting a host/run
+/// dep for them would add a runtime dependency the binary never dynamically
+/// loads, plus over-broad `run_exports` pinning, to the generated recipe.
+const VENDORED_STATIC_SYS_CRATES: &[&str] =
+    &["libdeflate-sys", "libz-sys", "libz-ng-sys", "bzip2-sys", "lzma-sys", "lz4-sys", "zstd-sys"];
+
+/// Returns true if `crate_name` vendors its C sources and statically links by
+/// default (so it needs only a C compiler, no system host library).
+pub fn is_vendored_static_sys_crate(crate_name: &str) -> bool {
+    VENDORED_STATIC_SYS_CRATES.contains(&crate_name)
+}
+
 /// Returns true if any dependency links C code.
 /// Detects `-sys` crates, the `cc` build crate, and crates that bundle their own C sources.
 pub fn needs_c_compiler(dependency_names: &[&str]) -> bool {
     dependency_names.iter().any(|name| {
-        *name == "cc" || !map_sys_crate(name).is_empty() || C_ONLY_CRATES.contains(name)
+        *name == "cc"
+            || !map_sys_crate(name).is_empty()
+            || C_ONLY_CRATES.contains(name)
+            || is_vendored_static_sys_crate(name)
     })
 }
 
@@ -104,15 +122,11 @@ pub fn needs_bindgen(dependency_names: &[&str]) -> bool {
 
 /// Returns true if any dependency typically needs pkg-config to locate system libraries.
 pub fn needs_pkg_config(dependency_names: &[&str]) -> bool {
+    // Vendored, static-by-default `-sys` crates (see VENDORED_STATIC_SYS_CRATES)
+    // are intentionally absent: they compile their own C sources and never need
+    // pkg-config to locate a system library.
     const PKG_CONFIG_CRATES: &[&str] = &[
         "openssl-sys",
-        "libz-sys",
-        "libz-ng-sys",
-        "bzip2-sys",
-        "lzma-sys",
-        "libdeflate-sys",
-        "lz4-sys",
-        "zstd-sys",
         "curl-sys",
         "libcurl-sys",
         "libsqlite3-sys",
@@ -130,8 +144,11 @@ pub fn needs_pkg_config(dependency_names: &[&str]) -> bool {
 
 /// Returns true if any dependency typically needs cmake to build.
 pub fn needs_cmake(dependency_names: &[&str]) -> bool {
+    // zstd-sys is intentionally excluded: it vendors its C sources and compiles
+    // them via the `cc` crate by default, so it needs neither cmake nor a system
+    // zstd (see VENDORED_STATIC_SYS_CRATES).
     const CMAKE_CRATES: &[&str] =
-        &["grpcio-sys", "rocksdb-sys", "snappy-sys", "leveldb-sys", "libssh2-sys", "zstd-sys"];
+        &["grpcio-sys", "rocksdb-sys", "snappy-sys", "leveldb-sys", "libssh2-sys"];
     dependency_names
         .iter()
         .any(|name| CMAKE_CRATES.contains(name) || *name == "cmake" || *name == "cmake-build")

--- a/tests/tier1.rs
+++ b/tests/tier1.rs
@@ -1017,7 +1017,10 @@ fn test_build_sh_no_cargo_net_git_fetch_by_default() {
 #[test]
 fn test_needs_pkg_config() {
     assert!(sys_deps::needs_pkg_config(&["openssl-sys", "serde"]));
-    assert!(sys_deps::needs_pkg_config(&["libz-sys"]));
+    assert!(sys_deps::needs_pkg_config(&["libgit2-sys"]));
+    // Vendored, static-by-default -sys crates never need pkg-config.
+    assert!(!sys_deps::needs_pkg_config(&["libz-sys"]));
+    assert!(!sys_deps::needs_pkg_config(&["libdeflate-sys", "zstd-sys"]));
     assert!(!sys_deps::needs_pkg_config(&["serde", "clap"]));
 }
 
@@ -1026,6 +1029,8 @@ fn test_needs_cmake() {
     assert!(sys_deps::needs_cmake(&["cmake", "serde"]));
     assert!(sys_deps::needs_cmake(&["rocksdb-sys"]));
     assert!(!sys_deps::needs_cmake(&["openssl-sys"]));
+    // zstd-sys vendors + compiles via the `cc` crate, so it needs no cmake.
+    assert!(!sys_deps::needs_cmake(&["zstd-sys"]));
 }
 
 #[test]

--- a/tests/tier3.rs
+++ b/tests/tier3.rs
@@ -2,18 +2,51 @@ mod common;
 
 use redskull_lib::recipe_builder::RecipeBuilder;
 use redskull_lib::renderer::{MetaYamlRenderer, Renderer};
-use redskull_lib::sys_deps::{detect_host_deps, map_sys_crate, needs_bindgen, needs_c_compiler};
+use redskull_lib::sys_deps::{
+    detect_host_deps, is_vendored_static_sys_crate, map_sys_crate, needs_bindgen, needs_c_compiler,
+    needs_cmake, needs_make, needs_pkg_config,
+};
 
 use common::*;
 
 #[test]
 fn test_simple_sys_mappings() {
     assert_eq!(map_sys_crate("openssl-sys"), vec![("openssl", Some("not osx"))]);
-    assert_eq!(map_sys_crate("libz-sys"), vec![("zlib", None)]);
-    assert_eq!(map_sys_crate("bzip2-sys"), vec![("bzip2", None)]);
-    assert_eq!(map_sys_crate("lzma-sys"), vec![("xz", None)]);
     assert_eq!(map_sys_crate("libcurl-sys"), vec![("libcurl", None)]);
     assert_eq!(map_sys_crate("libsqlite3-sys"), vec![("sqlite", None)]);
+    assert_eq!(map_sys_crate("libgit2-sys"), vec![("libgit2", None)]);
+}
+
+/// Crates that vendor their C sources and statically link by default must not
+/// produce a host/run mapping — they need only a C compiler.
+#[test]
+fn test_vendored_static_sys_crates_have_no_host_mapping() {
+    for crate_name in [
+        "libdeflate-sys",
+        "libz-sys",
+        "libz-ng-sys",
+        "bzip2-sys",
+        "lzma-sys",
+        "lz4-sys",
+        "zstd-sys",
+    ] {
+        assert!(is_vendored_static_sys_crate(crate_name), "{crate_name} should be vendored-static");
+        assert!(map_sys_crate(crate_name).is_empty(), "{crate_name} must not emit a host/run dep",);
+    }
+}
+
+/// A vendored, static-by-default `-sys` crate (libdeflate-sys, as in dupblaster)
+/// should produce a recipe needing only `compiler('c')`: no host/run dep, no
+/// pkg-config, no make, no cmake. Regression test for issue #32.
+#[test]
+fn test_libdeflate_sys_needs_only_c_compiler() {
+    let deps = ["libdeflater", "libdeflate-sys", "cc", "serde"];
+
+    assert!(needs_c_compiler(&deps), "libdeflate-sys still needs a C compiler");
+    assert!(detect_host_deps(&deps).is_empty(), "no host dep for vendored libdeflate-sys");
+    assert!(!needs_pkg_config(&deps), "no pkg-config for vendored libdeflate-sys");
+    assert!(!needs_make(&deps), "no make for vendored libdeflate-sys");
+    assert!(!needs_cmake(&deps), "no cmake for vendored libdeflate-sys");
 }
 
 #[test]
@@ -36,15 +69,18 @@ fn test_unknown_crate() {
 
 #[test]
 fn test_detect_host_deps() {
+    // libz-sys is vendored + static by default, so it contributes no host dep;
+    // only the genuinely system-linked openssl-sys does.
     let deps = detect_host_deps(&["serde", "openssl-sys", "clap", "libz-sys"]);
-    assert_eq!(deps.len(), 2);
+    assert_eq!(deps.len(), 1);
     assert!(deps.iter().any(|(n, _)| *n == "openssl"));
-    assert!(deps.iter().any(|(n, _)| *n == "zlib"));
 }
 
 #[test]
 fn test_needs_c_compiler() {
+    // Vendored -sys crates still need a C compiler even without a host mapping.
     assert!(needs_c_compiler(&["libz-sys", "serde"]));
+    assert!(needs_c_compiler(&["libdeflate-sys", "serde"]));
     assert!(needs_c_compiler(&["cc", "serde"]));
     assert!(!needs_c_compiler(&["serde", "clap", "tokio"]));
 }


### PR DESCRIPTION
## Summary

Fixes #32. `map_sys_crate` treated every compression `-sys` crate as a dynamically-linked system library, emitting a conda `host` + mirrored `run` dependency (plus `pkg-config`/`make` and `CPPFLAGS`/`LDFLAGS`/`CFLAGS` in `build.sh`). But `libdeflate-sys`, `libz-sys`, `libz-ng-sys`, `bzip2-sys`, `lzma-sys`, `lz4-sys`, and `zstd-sys` all vendor their C sources and statically link them by default via the `cc` crate — so they need only a C compiler.

The practical effect: a recipe generated for a tool that transitively pulls one of these crates (e.g. `dupblaster` → `libdeflater` → `libdeflate-sys`) declared a runtime `libdeflate` dependency the binary never dynamically loads, carried an over-broad `run_exports` pin into downstream environments, and pulled in unneeded build tools.

## Approach

This implements option 2/3 from the issue — a curated allowlist of vendor-by-default `-sys` crates:

- New `VENDORED_STATIC_SYS_CRATES` list (with `is_vendored_static_sys_crate`) feeds **only** the `needs_c_compiler` signal.
- These crates are removed from `map_sys_crate` (no host/run dep) and `PKG_CONFIG_CRATES` (no pkg-config). Because `needs_make` keys off `map_sys_crate`, they no longer trigger `make` either.
- `zstd-sys` is also dropped from `CMAKE_CRATES`: a vendored zstd-sys build uses `cc`, not cmake.
- Genuinely system-linked crates (`openssl-sys`, `libcurl-sys`, `libgit2-sys`, `libsqlite3-sys`, ...) and the `rust-htslib` bundle (which does dynamically link `zlib`/`bzip2`/`xz`/`libdeflate`/`libcurl`) are unchanged.

The result for `dupblaster` and friends is a recipe whose only C-side build requirement is `{{ compiler('c') }}`, matching the hand-written bioconda recipes referenced in the issue.

## Tests

- New `test_vendored_static_sys_crates_have_no_host_mapping` asserts the full vendored list produces no host/run mapping.
- New `test_libdeflate_sys_needs_only_c_compiler` is a regression test for the exact dupblaster scenario: C compiler yes; host dep / pkg-config / make / cmake no.
- Updated existing `map_sys_crate`, `detect_host_deps`, `needs_c_compiler`, and `needs_pkg_config` tests to reflect the new behavior (and to keep covering a genuinely system-linked crate).

`./ci/check.sh` passes (fmt, clippy `-D warnings`, all tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency detection for vendored compression libraries during builds.
  * Fixed incorrect pkg-config requirements for system-dependency crates including libz-sys and libdeflate-sys.
  * Corrected CMake and C compiler detection for zstd-sys and related crates.

* **Tests**
  * Added regression tests for vendored and statically-linked dependency handling.
  * Expanded test coverage for build system dependency detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->